### PR TITLE
fix: limit/offset types

### DIFF
--- a/fixes.yaml
+++ b/fixes.yaml
@@ -25,3 +25,9 @@ actions:
   - target: $["components"]["schemas"]["IdentificationLink"]["properties"]["type"]["enum"]
     update:
       - "oauth_apple"
+  - target: $["components"]["parameters"]["LimitParameter"]["schema"]
+    update:
+      type: integer
+  - target: $["components"]["parameters"]["OffsetParameter"]["schema"]
+    update:
+      type: integer


### PR DESCRIPTION
A `number` in OpenAPI is a decimal, not an int. 

In python, a `float(10)` will be represent as `10.0`: this is replicated on the wire when serialised into JSON by pydantic. 

This conflicts with the Clerk API which asserts that the value is an integer. 

Fixes #8, #7 after a regeneration of the SDK