### PR TITLE
chore: increase max method param threshold

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -33,7 +33,7 @@ python:
       shared: ""
       webhooks: ""
   inputModelSuffix: input
-  maxMethodParams: 4
+  maxMethodParams: 20
   methodArguments: infer-optional-args
   outputModelSuffix: output
   packageName: clerk-backend-api


### PR DESCRIPTION
This change updates a the gen.yaml config field `maxMethodParams` to 20 to ensure that parameters across all operations are flattened into keyword arguments on corresponding SDK methods.