### PR TITLE
fix: PR#18 compilation errors

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -14,10 +14,11 @@ generation:
 python:
   version: 0.5.0-alpha.12
   additionalDependencies:
-    dev: {}
-    main: 
-      cryptography: ^43.0.1
-      pyjwt: ^2.9.0
+    main:
+      cryptography: "^43.0.1"
+      pyjwt: "^2.9.0"
+    dev:
+      pytest: "^8.3.3"
   author: Clerk
   authors:
     - Clerk

--- a/src/clerk_backend_api/jwks_helpers/__init__.py
+++ b/src/clerk_backend_api/jwks_helpers/__init__.py
@@ -1,9 +1,9 @@
-
 from ..sdk import Clerk
 from .authenticaterequest import (
     AuthErrorReason,
     AuthStatus,
     AuthenticateRequestOptions,
+    RequestState,
     authenticate_request
 )
 from .verifytoken import (
@@ -17,6 +17,7 @@ __all__ = [
     "AuthErrorReason",
     "AuthStatus",
     "AuthenticateRequestOptions",
+    "RequestState",
     "authenticate_request",
     "TokenVerificationError",
     "TokenVerificationErrorReason",
@@ -26,4 +27,4 @@ __all__ = [
 
 
 # Attach authenticate_request method to the Clerk class
-Clerk.authenticate_request = authenticate_request
+setattr(Clerk, 'authenticate_request', authenticate_request)


### PR DESCRIPTION
This PR addresses compilation errors following PR #18 : 
- dependencies update through `.gen.yaml`
- additional check on type returned by [RSAAlgorithm.from_jwk()](https://github.com/jpadilla/pyjwt/blob/ca9a2cd8a3080f2a68638d29530d228e927100f4/jwt/algorithms.py#L403)
- explicit use of `setattr` in `jwks_helpers.__init__.py`