### PR TITLE
fix: #41 include jwt payload in RequestState

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,10 @@ from clerk_backend_api import Clerk
 from clerk_backend_api.jwks_helpers import AuthenticateRequestOptions, VerifyTokenOptions
 
 
+def has_env_vars(env_vars: List[str]) -> bool:
+    return all(os.getenv(var, "").strip() for var in env_vars)
+
+
 @pytest.fixture
 def secret_key() -> Optional[str]:
     """Secret Key from Clerk Dashboard."""

--- a/tests/test_authenticate_request.py
+++ b/tests/test_authenticate_request.py
@@ -23,7 +23,7 @@ def test_authenticate_request_no_session_token(clerk, request_url, ar_options):
     assert state.reason == AuthErrorReason.SESSION_TOKEN_MISSING
     assert 'Could not retrieve session token' in state.message
     assert state.token is None
-    # assert state.payload is None
+    assert state.payload is None
 
 
 def assert_request_state(state: RequestState, session_token: str, ar_options: AuthenticateRequestOptions):
@@ -31,12 +31,12 @@ def assert_request_state(state: RequestState, session_token: str, ar_options: Au
         assert state.message is None
         assert state.token is not None
         assert state.token == session_token
-        # assert state.payload is not None
-        # assert state.payload.get('azp') in ar_options.authorized_parties
+        assert state.payload is not None
+        assert state.payload.get('azp') in ar_options.authorized_parties
     else:
         assert state.reason == TokenVerificationErrorReason.TOKEN_EXPIRED
         assert state.token is None
-        # assert state.payload is None
+        assert state.payload is None
         warn("the provided session token is expired.")
 
 

--- a/tests/test_authenticate_request.py
+++ b/tests/test_authenticate_request.py
@@ -1,8 +1,20 @@
 import httpx
+import pytest
 from http.cookies import SimpleCookie
-from clerk_backend_api.jwks_helpers import AuthErrorReason
+from warnings import warn
+from .conftest import has_env_vars
+from clerk_backend_api.jwks_helpers import (
+    AuthErrorReason,
+    AuthenticateRequestOptions,
+    RequestState,
+    TokenVerificationErrorReason
+)
 
 
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_JWT_KEY']),
+    reason="CLERK_JWT_KEY environment variable must be set"
+)
 def test_authenticate_request_no_session_token(clerk, request_url, ar_options):
     request = httpx.Request('GET', request_url)
 
@@ -10,8 +22,28 @@ def test_authenticate_request_no_session_token(clerk, request_url, ar_options):
     assert not state.is_signed_in
     assert state.reason == AuthErrorReason.SESSION_TOKEN_MISSING
     assert 'Could not retrieve session token' in state.message
+    assert state.token is None
+    # assert state.payload is None
 
 
+def assert_request_state(state: RequestState, session_token: str, ar_options: AuthenticateRequestOptions):
+    if state.is_signed_in:
+        assert state.message is None
+        assert state.token is not None
+        assert state.token == session_token
+        # assert state.payload is not None
+        # assert state.payload.get('azp') in ar_options.authorized_parties
+    else:
+        assert state.reason == TokenVerificationErrorReason.TOKEN_EXPIRED
+        assert state.token is None
+        # assert state.payload is None
+        warn("the provided session token is expired.")
+
+
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_JWT_KEY', 'CLERK_SESSION_TOKEN']),
+    reason="CLERK_JWT_KEY and CLERK_SESSION_TOKEN environment variables must be set"
+)
 def test_authenticate_request_cookie(clerk, request_url, session_token, ar_options):
     with httpx.Client(cookies = {'__session': session_token}) as client:
         request = client.build_request('GET', request_url)
@@ -20,17 +52,17 @@ def test_authenticate_request_cookie(clerk, request_url, session_token, ar_optio
         assert cookies['__session'].value == session_token
 
         state = clerk.authenticate_request(request, ar_options)
-        assert state.is_signed_in
-        assert state.message is None
-        assert state.token == session_token
+        assert_request_state(state, session_token, ar_options)
 
 
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_JWT_KEY', 'CLERK_SESSION_TOKEN']),
+    reason="CLERK_JWT_KEY and CLERK_SESSION_TOKEN environment variables must be set"
+)
 def test_authenticate_request_header(clerk, request_url, session_token, ar_options):
     request = httpx.Request('GET', request_url)
     request.headers['Authorization'] = f'Bearer {session_token}'
 
     ar_options.secret_key = None
     state = clerk.authenticate_request(request, ar_options)
-    assert state.is_signed_in
-    assert state.message is None
-    assert state.token == session_token
+    assert_request_state(state, session_token, ar_options)

--- a/tests/test_verify_token.py
+++ b/tests/test_verify_token.py
@@ -1,12 +1,19 @@
 import jwt
 import pytest
+from warnings import warn
+from .conftest import has_env_vars
 from clerk_backend_api.jwks_helpers import (
     verify_token,
     TokenVerificationErrorReason,
     TokenVerificationError,
+    VerifyTokenOptions,
 )
 
 
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_SECRET_KEY']),
+    reason="CLERK_SECRET_KEY environment variable must be set"
+)
 def test_verify_token_invalid_token(vt_options):
 
     vt_options.jwt_key = None
@@ -16,6 +23,10 @@ def test_verify_token_invalid_token(vt_options):
     assert exc_info.value.reason == TokenVerificationErrorReason.TOKEN_INVALID
 
 
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_SECRET_KEY']),
+    reason="CLERK_SECRET_KEY environment variable must be set"
+)
 def test_verify_token_public_key_invalid_kid(vt_options):
 
     vt_options.jwt_key = None
@@ -26,6 +37,10 @@ def test_verify_token_public_key_invalid_kid(vt_options):
     assert exc_info.value.reason == TokenVerificationErrorReason.JWK_KID_MISMATCH
 
 
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_SESSION_TOKEN']),
+    reason="CLERK_SESSION_TOKEN environment variable must be set"
+)
 def test_verify_token_missing_secret_key(session_token, vt_options):
 
     vt_options.jwt_key = None
@@ -36,6 +51,10 @@ def test_verify_token_missing_secret_key(session_token, vt_options):
     assert exc_info.value.reason == TokenVerificationErrorReason.SECRET_KEY_MISSING
 
 
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_SESSION_TOKEN']),
+    reason="CLERK_SESSION_TOKEN environment variable must be set"
+)
 def test_verify_token_invalid_secret_key(session_token, vt_options):
 
     vt_options.jwt_key = None
@@ -46,6 +65,10 @@ def test_verify_token_invalid_secret_key(session_token, vt_options):
     assert exc_info.value.reason == TokenVerificationErrorReason.JWK_FAILED_TO_LOAD
 
 
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_SESSION_TOKEN']),
+    reason="CLERK_SESSION_TOKEN environment variable must be set"
+)
 def test_verify_token_invalid_jwt_key(session_token, vt_options):
 
     vt_options.jwt_key = 'invalid_pem_key'
@@ -56,18 +79,41 @@ def test_verify_token_invalid_jwt_key(session_token, vt_options):
     assert exc_info.value.reason == TokenVerificationErrorReason.JWK_FAILED_TO_RESOLVE
 
 
+def assert_payload(session_token: str, vt_options: VerifyTokenOptions):
+    payload = {}
+    expired = False
+
+    try:
+        payload = verify_token(session_token, vt_options)
+    except TokenVerificationError as e:
+        if e.reason != TokenVerificationErrorReason.TOKEN_EXPIRED:
+            raise
+        expired = True
+        warn("the provided session token is expired.")
+
+    if expired:
+        assert payload == {}
+    else:
+        assert payload.get('azp') in vt_options.authorized_parties
+
+
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_SECRET_KEY', 'CLERK_SESSION_TOKEN']),
+    reason="CLERK_SECRET_KEY and CLERK_SESSION_TOKEN environment variables must be set"
+)
 def test_verify_token_remote_ok(session_token, vt_options):
 
     vt_options.jwt_key = None
-    payload = verify_token(session_token, vt_options)
-    assert payload is not None
-    assert payload.get('azp') in vt_options.authorized_parties
+
+    assert_payload(session_token, vt_options)
 
 
+@pytest.mark.skipif(
+    not has_env_vars(['CLERK_JWT_KEY', 'CLERK_SESSION_TOKEN']),
+    reason="CLERK_JWT_KEY and CLERK_SESSION_TOKEN environment variables must be set"
+)
 def test_verify_token_local_ok(session_token, vt_options):
 
     assert vt_options.jwt_key is not None
 
-    payload = verify_token(session_token, vt_options)
-    assert payload is not None
-    assert payload.get('azp') in vt_options.authorized_parties
+    assert_payload(session_token, vt_options)


### PR DESCRIPTION
This PR addresses #41 by including the `payload` in the returned `RequestState` object.

Incidentally, tests were improved to allow:
- skipping tests if environment variables are missing
- passing tests even if the provided token is expired (with warnings)