### PR TITLE
fix: move secret_key logic to SDK class to prevent circular import

### DIFF
--- a/src/clerk_backend_api/jwks_helpers/__init__.py
+++ b/src/clerk_backend_api/jwks_helpers/__init__.py
@@ -1,4 +1,3 @@
-from ..sdk import Clerk
 from .authenticaterequest import (
     AuthErrorReason,
     AuthStatus,


### PR DESCRIPTION
In an attempt to provide Intellisense support for the `clerk.authenticate_request` method [PR#86](https://github.com/clerk/clerk-sdk-python/pull/86) introduced a circular import error preventing from running tests:
```
poetry run pytest

ImportError while loading conftest 'clerk-sdk-python/tests/conftest.py'.
tests/conftest.py:4: in <module>
    from clerk_backend_api import Clerk
src/clerk_backend_api/__init__.py:10: in <module>
    from .sdk import *
src/clerk_backend_api/sdk.py:50: in <module>
    from .jwks_helpers.authenticaterequest import authenticate_request
src/clerk_backend_api/jwks_helpers/__init__.py:1: in <module>
    from ..sdk import Clerk
E   ImportError: cannot import name 'Clerk' from partially initialized module 'clerk_backend_api.sdk' (most likely due to a circular import) (clerk-sdk-python/src/clerk_backend_api/sdk.py)
```

This PR moves the logic that tries to retrieve the `secret_key` from the `bearer_auth` (passed during SDK instantiation) into the main SDK class to prevent circular import.