### PR TITLE
Remove unnecessary `warn()` in JWT validation code

### DIFF
--- a/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
+++ b/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
@@ -73,8 +73,6 @@ def authenticate_request(request: httpx.Request, options: AuthenticateRequestOpt
     Otherwise, performs a network call to retrieve the JWKS from Clerk's Backend API.
     """
 
-    warn('authenticate_request method is applicable in the context of Backend APIs only.')
-
     def get_session_token(request: httpx.Request) -> Optional[str]:
         """Retrieve token from __session cookie or Authorization header."""
 


### PR DESCRIPTION
There is a `warn()` that indicates that `authenticate_request` should only be used for backend API requests.

This is showing up in various logs in my app (tests, access logs, etc) without providing insight that couldn't be determined from just reading the project's documentation.