### PR TITLE
bump version and use Protocol class to support fastapi and django

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clerk-backend-api"
-version = "1.8.0"
+version = "1.8.1"
 description = "Python Client SDK for clerk.dev"
 authors = [{ name = "Clerk" },]
 readme = "README-PYPI.md"

--- a/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
+++ b/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
@@ -88,9 +88,10 @@ def authenticate_request(request: Requestish, options: AuthenticateRequestOption
 
         cookie_header = request.headers.get('cookie')
         if cookie_header is not None:
-            session_cookie = SimpleCookie(cookie_header).get('__session')
-            if session_cookie is not None:
-                return session_cookie.value
+            if cookie_header is not None:
+                for key, value in SimpleCookie(cookie_header).iteritems():
+                    if key.startswith("__session"):
+                        return value
 
         return None
 

--- a/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
+++ b/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
@@ -1,11 +1,15 @@
-import httpx
 from dataclasses import dataclass
 from enum import Enum
 from http.cookies import SimpleCookie
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, List, Union, Optional, Protocol
 from warnings import warn
 
 from .verifytoken import TokenVerificationErrorReason, TokenVerificationError, VerifyTokenOptions, verify_token
+
+
+class Requestish(Protocol):
+    def headers(self) -> Dict[str, str]: ...
+
 
 
 class AuthErrorReason(Enum):
@@ -68,14 +72,14 @@ class AuthenticateRequestOptions:
     authorized_parties: Optional[List[str]] = None
     clock_skew_in_ms: int = 5000
 
-def authenticate_request(request: httpx.Request, options: AuthenticateRequestOptions) -> RequestState:
+def authenticate_request(request: Requestish, options: AuthenticateRequestOptions) -> RequestState:
     """ Authenticates the session token. Networkless if the options.jwt_key is provided.
     Otherwise, performs a network call to retrieve the JWKS from Clerk's Backend API.
     """
 
     warn('authenticate_request method is applicable in the context of Backend APIs only.')
 
-    def get_session_token(request: httpx.Request) -> Optional[str]:
+    def get_session_token(request: Requestish) -> Optional[str]:
         """Retrieve token from __session cookie or Authorization header."""
 
         bearer_token = request.headers.get('Authorization')


### PR DESCRIPTION
This update uses Protocol typing to support both django and fastapi request types without any extra dependencies.