### PR TITLE
Improve Requestish type

### DIFF
--- a/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
+++ b/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
@@ -13,7 +13,9 @@ from .verifytoken import (
 
 
 class Requestish(Protocol):
-    headers: Dict[str, str]
+    @property
+    def headers(self) -> Mapping[str, str]:
+        ...
 
 
 class AuthErrorReason(Enum):

--- a/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
+++ b/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from http.cookies import SimpleCookie
-from typing import Any, Dict, List, Union, Optional, Protocol
+from typing import Any, Dict, List, Union, Optional, Protocol, Mapping
 from warnings import warn
 
 from .verifytoken import (


### PR DESCRIPTION
Currently certain type checkers don't accept usage of `fastapi`'s `Request` as an argument for `authenticate_request` because of a type discrepancy.
The error I'm getting with [basedpyright](https://docs.basedpyright.com/v1.28.3/) is this:
```
Argument of type "Request" cannot be assigned to parameter "request" of type "Requestish" in function "authenticate_request"
  "Request" is incompatible with protocol "Requestish"
    "headers" is invariant because it is mutable
    "headers" is an incompatible type
      "property" is not assignable to "Dict[str, str]"
```

I changed the `Requestish` type to be more correct to its usage.  
There are no checker linter warnings now.