### PR TITLE
Handle V2 JWT format 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "clerk-backend-api"
 version = "2.1.0"
 description = "Python Client SDK for clerk.dev"
 authors = [{ name = "Clerk" },]
-readme = "README-PYPI.md"
+readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "cryptography (>=43.0.1,<44.0.0)",

--- a/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
+++ b/src/clerk_backend_api/jwks_helpers/authenticaterequest.py
@@ -79,6 +79,51 @@ class AuthenticateRequestOptions:
     clock_skew_in_ms: int = 5000
 
 def authenticate_request(request: Requestish, options: AuthenticateRequestOptions) -> RequestState:
+
+    def __compute_org_permissions(claims: Dict[str, Any]) -> List[str]:
+        features_str = claims.get("fea")
+        if features_str is None:
+            return []
+
+        org_claims = claims.get("o", {})
+        permissions_str = org_claims.get("per")
+        mappings_str = org_claims.get("fpm")
+
+        if not all(isinstance(s, str) for s in [permissions_str, mappings_str]):
+            return []
+
+        features = features_str.split(",")
+        permissions = permissions_str.split(",")
+        mappings = mappings_str.split(",")
+
+        org_permissions = []
+
+        for idx in range(len(mappings)):
+            if idx >= len(features):
+                continue
+
+            mapping = mappings[idx]
+            feature_parts = features[idx].split(":")
+            if len(feature_parts) != 2:
+                continue
+
+            scope, feature = feature_parts
+            if "o" not in scope:
+                continue
+
+            try:
+                binary = bin(int(mapping))[2:].lstrip("0")
+            except ValueError:
+                continue
+
+            reversed_binary = binary[::-1]
+
+            for i, bit in enumerate(reversed_binary):
+                if bit == "1" and i < len(permissions):
+                    org_permissions.append(f"org:{feature}:{permissions[i]}")
+
+        return org_permissions
+
     """ Authenticates the session token. Networkless if the options.jwt_key is provided.
     Otherwise, performs a network call to retrieve the JWKS from Clerk's Backend API.
     """
@@ -122,7 +167,23 @@ def authenticate_request(request: Requestish, options: AuthenticateRequestOption
             ),
         )
 
+        if payload is not None and payload.get("v") == 2:
+            org_claims = payload.get("o", {})
+            if org_claims:
+                payload["org_id"] = org_claims.get("id")
+                payload["org_slug"] = org_claims.get("slg")
+                payload["org_role"] = org_claims.get("rol")
+
+                org_permissions = __compute_org_permissions(payload)
+                if org_permissions:
+                    payload["org_permissions"] = org_permissions
+
         return RequestState(status=AuthStatus.SIGNED_IN, token=session_token, payload=payload)
 
     except TokenVerificationError as e:
         return RequestState(status=AuthStatus.SIGNED_OUT, reason=e.reason)
+
+
+
+
+

--- a/tests/test_authenticate_request.py
+++ b/tests/test_authenticate_request.py
@@ -19,14 +19,25 @@ def session_token():
     return "dummy.jwt.token"
 
 @pytest.fixture
-def default_options():
+def default_options_with_secret_key():
     return AuthenticateRequestOptions(
         secret_key="test-secret",
+        jwt_key=None,
+        audience="test-audience",
+        authorized_parties=["https://example.com"],
+        clock_skew_in_ms=5000
+    )
+
+@pytest.fixture
+def default_options_with_jwt_key():
+    return AuthenticateRequestOptions(
+        secret_key=None,
         jwt_key="test-jwt-key",
         audience="test-audience",
         authorized_parties=["https://example.com"],
         clock_skew_in_ms=5000
     )
+
 
 def make_headers(auth_token=None, cookie=None):
     headers = {}
@@ -47,9 +58,9 @@ def assert_verify_called_with(mock_verify, token, opts: AuthenticateRequestOptio
     assert actual_options.authorized_parties == opts.authorized_parties
     assert actual_options.clock_skew_in_ms == opts.clock_skew_in_ms
 
-def test_missing_token_returns_signed_out(default_options):
+def test_missing_token_returns_signed_out(default_options_with_secret_key):
     request = MockRequest(headers={})
-    state = authenticate_request(request, default_options)
+    state = authenticate_request(request, default_options_with_secret_key)
     assert state.status == AuthStatus.SIGNED_OUT
     assert state.reason == AuthErrorReason.SESSION_TOKEN_MISSING
 
@@ -60,8 +71,16 @@ def test_missing_secret_key_returns_signed_out(session_token):
     assert state.status == AuthStatus.SIGNED_OUT
     assert state.reason == AuthErrorReason.SECRET_KEY_MISSING
 
+def test_missing_jwt_key_returns_signed_out(session_token):
+    request = MockRequest(headers=make_headers(auth_token=session_token))
+    opts = AuthenticateRequestOptions(secret_key=None, jwt_key=None)
+    state = authenticate_request(request, opts)
+    assert state.status == AuthStatus.SIGNED_OUT
+    assert state.reason == AuthErrorReason.SECRET_KEY_MISSING
+
+
 @patch("clerk_backend_api.jwks_helpers.authenticaterequest.verify_token", autospec=True)
-def test_valid_v1_token(mock_verify_token, session_token, default_options):
+def test_valid_v1_token(mock_verify_token, session_token, default_options_with_secret_key):
     mock_verify_token.return_value = {
         "sub": "user_123",
         "aud": "test-audience",
@@ -69,15 +88,31 @@ def test_valid_v1_token(mock_verify_token, session_token, default_options):
     }
 
     request = MockRequest(headers=make_headers(auth_token=session_token))
-    state = authenticate_request(request, default_options)
+    state = authenticate_request(request, default_options_with_secret_key)
 
     assert state.status == AuthStatus.SIGNED_IN
     assert state.payload["sub"] == "user_123"
     assert "org_permissions" not in state.payload
-    assert_verify_called_with(mock_verify_token, session_token, default_options)
+    assert_verify_called_with(mock_verify_token, session_token, default_options_with_secret_key)
 
 @patch("clerk_backend_api.jwks_helpers.authenticaterequest.verify_token", autospec=True)
-def test_valid_v2_token_without_org(mock_verify_token, session_token, default_options):
+def test_valid_v1_token_with_jwt_key(mock_verify_token, session_token, default_options_with_jwt_key):
+    mock_verify_token.return_value = {
+        "sub": "user_123",
+        "aud": "test-audience",
+        "iss": "https://api.clerk.com"
+    }
+
+    request = MockRequest(headers=make_headers(auth_token=session_token))
+    state = authenticate_request(request, default_options_with_jwt_key)
+
+    assert state.status == AuthStatus.SIGNED_IN
+    assert state.payload["sub"] == "user_123"
+    assert "org_permissions" not in state.payload
+    assert_verify_called_with(mock_verify_token, session_token, default_options_with_jwt_key)
+
+@patch("clerk_backend_api.jwks_helpers.authenticaterequest.verify_token", autospec=True)
+def test_valid_v2_token_without_org(mock_verify_token, session_token, default_options_with_secret_key):
     mock_verify_token.return_value = {
         "sub": "user_123",
         "v": 2,
@@ -87,14 +122,31 @@ def test_valid_v2_token_without_org(mock_verify_token, session_token, default_op
     }
 
     request = MockRequest(headers=make_headers(auth_token=session_token))
-    state = authenticate_request(request, default_options)
+    state = authenticate_request(request, default_options_with_secret_key)
 
     assert state.status == AuthStatus.SIGNED_IN
     assert "org_permissions" not in state.payload
-    assert_verify_called_with(mock_verify_token, session_token, default_options)
+    assert_verify_called_with(mock_verify_token, session_token, default_options_with_secret_key)
 
 @patch("clerk_backend_api.jwks_helpers.authenticaterequest.verify_token", autospec=True)
-def test_valid_v2_token_with_org_permissions(mock_verify_token, session_token, default_options):
+def test_valid_v2_token_without_org_with_jwt_key(mock_verify_token, session_token, default_options_with_jwt_key):
+    mock_verify_token.return_value = {
+        "sub": "user_123",
+        "v": 2,
+        "fea": "u:foo,u:bar",
+        "aud": "test-audience",
+        "iss": "https://api.clerk.com"
+    }
+
+    request = MockRequest(headers=make_headers(auth_token=session_token))
+    state = authenticate_request(request, default_options_with_jwt_key)
+
+    assert state.status == AuthStatus.SIGNED_IN
+    assert "org_permissions" not in state.payload
+    assert_verify_called_with(mock_verify_token, session_token, default_options_with_jwt_key)
+
+@patch("clerk_backend_api.jwks_helpers.authenticaterequest.verify_token", autospec=True)
+def test_valid_v2_token_with_org_permissions(mock_verify_token, session_token, default_options_with_secret_key):
     mock_verify_token.return_value = {
         "sub": "user_123",
         "v": 2,
@@ -111,22 +163,49 @@ def test_valid_v2_token_with_org_permissions(mock_verify_token, session_token, d
     }
 
     request = MockRequest(headers=make_headers(auth_token=session_token))
-    state = authenticate_request(request, default_options)
+    state = authenticate_request(request, default_options_with_secret_key)
 
     assert state.status == AuthStatus.SIGNED_IN
     assert state.payload["org_id"] == "org_abc"
     assert state.payload["org_slug"] == "org-slug"
     assert state.payload["org_role"] == "owner"
     assert "org:admin:view" in state.payload["org_permissions"] or "org:reports:edit" in state.payload["org_permissions"]
-    assert_verify_called_with(mock_verify_token, session_token, default_options)
+    assert_verify_called_with(mock_verify_token, session_token, default_options_with_secret_key)
 
 @patch("clerk_backend_api.jwks_helpers.authenticaterequest.verify_token", autospec=True)
-def test_token_verification_error_returns_signed_out(mock_verify_token, session_token, default_options):
+def test_valid_v2_token_with_org_permissions_with_jwt_key(mock_verify_token, session_token, default_options_with_jwt_key):
+    mock_verify_token.return_value = {
+        "sub": "user_123",
+        "v": 2,
+        "fea": "o:admin,o:reports",
+        "o": {
+            "id": "org_abc",
+            "slg": "org-slug",
+            "rol": "owner",
+            "per": "view,edit",
+            "fpm": "1,2"
+        },
+        "aud": "test-audience",
+        "iss": "https://api.clerk.com"
+    }
+
+    request = MockRequest(headers=make_headers(auth_token=session_token))
+    state = authenticate_request(request, default_options_with_jwt_key)
+
+    assert state.status == AuthStatus.SIGNED_IN
+    assert state.payload["org_id"] == "org_abc"
+    assert state.payload["org_slug"] == "org-slug"
+    assert state.payload["org_role"] == "owner"
+    assert "org:admin:view" in state.payload["org_permissions"] or "org:reports:edit" in state.payload["org_permissions"]
+    assert_verify_called_with(mock_verify_token, session_token, default_options_with_jwt_key)
+
+@patch("clerk_backend_api.jwks_helpers.authenticaterequest.verify_token", autospec=True)
+def test_token_verification_error_returns_signed_out(mock_verify_token, session_token, default_options_with_secret_key):
     mock_verify_token.side_effect = TokenVerificationError(reason=TokenVerificationErrorReason.TOKEN_INVALID)
 
     request = MockRequest(headers=make_headers(auth_token=session_token))
-    state = authenticate_request(request, default_options)
+    state = authenticate_request(request, default_options_with_secret_key)
 
     assert state.status == AuthStatus.SIGNED_OUT
     assert state.reason == TokenVerificationErrorReason.TOKEN_INVALID
-    assert_verify_called_with(mock_verify_token, session_token, default_options)
+    assert_verify_called_with(mock_verify_token, session_token, default_options_with_secret_key)


### PR DESCRIPTION
This PR adds support for handling v2 claims format, it converts new claims to old format while retain new claims as it is, so if the clients prefer , they can upgrade at the time of their convenience. It also removes dependency on secret keys / jwt keys, and instead mocks them 

<img width="1067" alt="Screenshot 2025-05-12 at 1 52 26 PM" src="https://github.com/user-attachments/assets/ad225232-ce5e-434a-9732-33c22841ce77" />
 