### PR TITLE
chore: update cryptograpy additional dep

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -21,7 +21,7 @@ python:
     dev:
       pytest: ^8.3.3
     main:
-      cryptography: ^43.0.1
+      cryptography: ^44.0.1
       pyjwt: ^2.9.0
   author: Clerk
   authors:


### PR DESCRIPTION
This PR updates the additional dep `cryptography` which is added to support the custom code in `verifytoken.py`. Version `43.0.1` has a low severity security vulnerability https://github.com/pyca/cryptography/security/advisories/GHSA-79v4-65xg-pq4g 