### PR TITLE
Fix: broken release 3.0.0

### DIFF
--- a/src/clerk_backend_api/_hooks/clerk_before_request_hook.py
+++ b/src/clerk_backend_api/_hooks/clerk_before_request_hook.py
@@ -2,7 +2,6 @@ from typing import Union
 
 import httpx
 
-from .. import VERSION
 from .types import (
     BeforeRequestContext,
     BeforeRequestHook,
@@ -12,6 +11,8 @@ class ClerkBeforeRequestHook(BeforeRequestHook):
     def before_request(
         self, hook_ctx: BeforeRequestContext, request: httpx.Request
     ) -> Union[httpx.Request, Exception]:
+        from .. import VERSION
+
         request.headers["Clerk-API-Version"] = "2025-04-10"
         request.headers["X-Clerk-SDK"] = f"python/{VERSION}"
 

--- a/tests/test_clerk_before_request_hook.py
+++ b/tests/test_clerk_before_request_hook.py
@@ -16,6 +16,7 @@ def hook():
 def hook_context():
     """HookContext instance"""
     return HookContext(
+        config=None,
         base_url="https://api.clerk.dev",
         operation_id="test_operation",
         oauth2_scopes=None,
@@ -40,7 +41,7 @@ def test_before_request_adds_api_version_header(hook, before_request_context):
     
     # Assert that the Clerk-API-Version header is added with the correct value
     assert "Clerk-API-Version" in modified_request.headers
-    assert modified_request.headers["Clerk-API-Version"] == "2024-10-01"
+    assert modified_request.headers["Clerk-API-Version"] == "2025-04-10"
     
     # Assert that the original request is modified, not a new one created
     assert modified_request is request
@@ -63,7 +64,7 @@ def test_before_request_preserves_existing_headers(hook, before_request_context)
     assert modified_request.headers["Content-Type"] == "application/json"
     
     # Assert that the Clerk-API-Version header is added
-    assert modified_request.headers["Clerk-API-Version"] == "2024-10-01"
+    assert modified_request.headers["Clerk-API-Version"] == "2025-04-10"
 
 
 def test_before_request_overwrites_existing_api_version_header(hook, before_request_context):
@@ -79,4 +80,4 @@ def test_before_request_overwrites_existing_api_version_header(hook, before_requ
     modified_request = hook.before_request(before_request_context, request)
     
     # Assert that the Clerk-API-Version header is overwritten
-    assert modified_request.headers["Clerk-API-Version"] == "2024-10-01"
+    assert modified_request.headers["Clerk-API-Version"] == "2025-04-10"


### PR DESCRIPTION
Source of broken release: https://github.com/clerk/clerk-sdk-python/commit/273a2b634e1ef2bdd3ece8d21194771b57839cfc 