### PR TITLE
docs: fixed broken twitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <br></br>
 
 [![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
+[![twitter](https://img.shields.io/twitter/follow/Clerk?style=social)](https://twitter.com/intent/follow?screen_name=Clerk)
 
 <!-- Start Summary [summary] -->
 ## Summary


### PR DESCRIPTION
The Clerk Twitter account is now `@Clerk` instead of `@ClerkDev` so the existing link was directing to the wrong account