### PR TITLE
Update Clerk API version and cryptography constraint

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ python:
     dev:
       pytest: ^8.3.3
     main:
-      cryptography: '>=45.0.0,<47.0.0'
+      cryptography: '>=45.0.0,<49.0.0'
       pyjwt: ^2.9.0
   allowedRedefinedBuiltins:
     - id

--- a/tests/test_clerk_before_request_hook.py
+++ b/tests/test_clerk_before_request_hook.py
@@ -41,7 +41,7 @@ def test_before_request_adds_api_version_header(hook, before_request_context):
     
     # Assert that the Clerk-API-Version header is added with the correct value
     assert "Clerk-API-Version" in modified_request.headers
-    assert modified_request.headers["Clerk-API-Version"] == "2025-04-10"
+    assert modified_request.headers["Clerk-API-Version"] == "2025-11-10"
     
     # Assert that the original request is modified, not a new one created
     assert modified_request is request
@@ -64,7 +64,7 @@ def test_before_request_preserves_existing_headers(hook, before_request_context)
     assert modified_request.headers["Content-Type"] == "application/json"
     
     # Assert that the Clerk-API-Version header is added
-    assert modified_request.headers["Clerk-API-Version"] == "2025-04-10"
+    assert modified_request.headers["Clerk-API-Version"] == "2025-11-10"
 
 
 def test_before_request_overwrites_existing_api_version_header(hook, before_request_context):
@@ -80,4 +80,4 @@ def test_before_request_overwrites_existing_api_version_header(hook, before_requ
     modified_request = hook.before_request(before_request_context, request)
     
     # Assert that the Clerk-API-Version header is overwritten
-    assert modified_request.headers["Clerk-API-Version"] == "2025-04-10"
+    assert modified_request.headers["Clerk-API-Version"] == "2025-11-10"


### PR DESCRIPTION
## Summary
- Update the generated Python dependency constraint for `cryptography` to allow version 48
- Refresh before-request hook tests to expect the new Clerk API version header `2025-11-10`