### PR TITLE
Allow cryptography >=45.0.0,<51.0.0

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ python:
     dev:
       pytest: ^8.3.3
     main:
-      cryptography: '>=45.0.0,<49.0.0'
+      cryptography: '>=45.0.0,<51.0.0'
       pyjwt: ^2.9.0
   allowedRedefinedBuiltins:
     - id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Clerk" },]
 readme = "README-PYPI.md"
 requires-python = ">=3.10"
 dependencies = [
-    "cryptography >=45.0.0,<49.0.0",
+    "cryptography >=45.0.0,<51.0.0",
     "httpcore >=1.0.9",
     "httpx >=0.28.1",
     "pydantic >=2.11.2",
@@ -57,5 +57,4 @@ ignore_missing_imports = true
 [tool.pyright]
 venvPath = "."
 venv = ".venv"
-
 


### PR DESCRIPTION
## Summary

Widen the supported `cryptography` range to `>=45.0.0,<51.0.0`, allowing downstream users to install the remediated 50.x release line.

Closes #244.

## Why

[CVE-2026-69247](https://github.com/pyca/cryptography/security/advisories/GHSA-g6cj-pr64-35w5) affects `cryptography >=44.0.0,<50.0.0`. The current `<49.0.0` ceiling prevents downstream users from installing the remediated `cryptography` 50.x release line.

[PR #238](https://github.com/clerk/clerk-sdk-python/pull/238) is the precedent for raising this ceiling in `.speakeasy/gen.yaml`. This change keeps the constraint in `.speakeasy/gen.yaml`, the Speakeasy source of truth, so the next SDK regeneration propagates it, matching how #238 was done. `pyproject.toml` is also updated because the regeneration immediately following #238 synced the previous constraint change there.

No generated SDK code is changed.

## Validation

Environment setup:

```console
$ uv venv --python 3.12 .venv
$ uv pip install --python .venv/bin/python -e . 'pytest==8.3.3' 'pytest-asyncio==0.24.0' 'cryptography==50.0.0'
...
 + cryptography==50.0.0
```

Installed version and full test suite:

```console
$ ./.venv/bin/python -c 'import cryptography; print(cryptography.__version__)'
50.0.0
$ ./.venv/bin/pytest -q
.......................................ssssssssssssss................... [ 98%]
.                                                                        [100%]
59 passed, 14 skipped in 0.21s
```

The skipped tests are credential-gated. Additional credentialed testing found a pre-existing, order-dependent `test_verify_token_invalid_secret_key` failure caused by the module-global JWKS cache; it reproduces with both `cryptography` 48 and 50 and is therefore cryptography-independent. Resetting that cache between tests yields `71 passed, 2 skipped` with either version. No test workaround is included here so this PR remains scoped to the dependency bounds. (Root cause and fix are in #246.)

The suite includes the JWT/JWKS and request-authentication coverage in `test_verify_token.py`, `test_authenticate_request.py`, and `test_clerk_before_request_hook.py`.