### PR TITLE
Fix order-dependent test failures from shared JWKS cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,20 @@ import os
 import pytest
 from typing import Optional, Union, List
 from clerk_backend_api import Clerk
+from clerk_backend_api.security import verifytoken
 from clerk_backend_api.security.types import AuthenticateRequestOptions, VerifyTokenOptions
 
 
 def has_env_vars(env_vars: List[str]) -> bool:
     return all(os.getenv(var, "").strip() for var in env_vars)
+
+
+@pytest.fixture(autouse=True)
+def clear_jwk_cache():
+    """The module-global JWKS cache in verifytoken is keyed only by kid, so a
+    key cached by one test lets later tests skip the network fetch entirely,
+    making error-path tests order-dependent. Start every test with a cold cache."""
+    getattr(verifytoken, '__jwkcache').cache.clear()
 
 
 @pytest.fixture


### PR DESCRIPTION
The credentialed test suite has one test that fails or passes depending on execution order. This PR fixes it by clearing the JWKS cache between tests. It touches only `tests/conftest.py`, which is hand-maintained (not listed in `.speakeasy/gen.lock`). No generated or production code changes.

## Steps to reproduce

With `CLERK_SECRET_KEY` and a fresh `CLERK_SESSION_TOKEN` set, run these two tests in the same pytest process, in this order (the same order the full suite uses):

```python
    pytest "tests/test_verify_token.py::TestJwtVerification::test_verify_token_remote_ok" \
           "tests/test_verify_token.py::TestJwtVerificationAsync::test_verify_token_invalid_secret_key"
```

## Expected and actual behavior

Expected: `test_verify_token_invalid_secret_key` calls `verify_token_async` with `secret_key='sk_test_invalid'`, the JWKS fetch gets a 401, and the test sees `JWK_FAILED_TO_LOAD`.

Actual: the test fails with `DID NOT RAISE` (or, if the session token has expired, with `TOKEN_EXPIRED`). Run alone, the same test passes.

## Root cause

`src/clerk_backend_api/security/verifytoken.py` keeps a module-global `__jwkcache` shared by the sync and async paths and keyed only by JWT `kid`. The sync `test_verify_token_remote_ok` runs earlier in the suite, fetches the JWKS with the valid secret key, and caches the PEM. When the async invalid-secret-key test runs, `_get_remote_jwt_key_async` finds the cached PEM and returns it without contacting Clerk, so the invalid key is never used and the expected error never happens.

This is the cache working as designed in production. The problem is test isolation: nothing resets the cache between tests, so the error-path tests only pass from a cold start. The sync twin of this test passes today only because it happens to run before `remote_ok`.

## Fix

An autouse fixture in `tests/conftest.py` that clears the cache before each test. Results with credentials: 71 passed, 2 skipped (was 1 failed, 70 passed, 2 skipped). Without credentials: 59 passed, 14 skipped, same as before, so CI and uncredentialed runs are unaffected. Verified identical under cryptography 48.0.0 and 50.0.0; the failure predates any dependency changes and is unrelated to #245.

## Environment

Python 3.12.12, macOS (darwin arm64), pytest 8.x, pytest-asyncio 0.24.0,
PyJWT 2.13.0. Reproduced with cryptography 48.0.0 and 50.0.0.