### PR TITLE
fix(security): Scope JWKS cache entries per Clerk instance

### DIFF
--- a/src/clerk_backend_api/security/verifytoken.py
+++ b/src/clerk_backend_api/security/verifytoken.py
@@ -1,6 +1,7 @@
+import hashlib
 import re
 from datetime import timedelta
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, cast
 
 import httpx
 import jwt
@@ -13,6 +14,24 @@ from .machine import get_token_type
 from .types import TokenType, VerifyTokenOptions, TokenVerificationError, TokenVerificationErrorReason
 
 __jwkcache = Cache()
+
+
+def _jwk_cache_key(options: VerifyTokenOptions, kid: Optional[str]) -> Optional[str]:
+    """ Scope a kid to the Clerk instance whose credentials fetched it.
+
+    A Clerk kid is the instance id, so a cache keyed on kid alone serves one
+    instance's signing key to another instance's verification in the same
+    process, letting a token minted by instance B authenticate against
+    instance A (AISEC-82).
+    """
+    if kid is None:
+        return None
+
+    scope = hashlib.sha256(
+        f'{options.api_url}\0{options.secret_key}'.encode('utf-8')
+    ).hexdigest()
+    return f'{scope}:{kid}'
+
 
 verification_apis = {
     TokenType.MACHINE_TOKEN : '/m2m_tokens/verify',
@@ -80,7 +99,7 @@ def _verify_session_token(token: str, options: VerifyTokenOptions) -> Dict[str, 
 
         # Key rotation: evict stale cached key, re-fetch, and retry once
         kid = jwt.get_unverified_header(token).get('kid')
-        __jwkcache.delete(kid)
+        __jwkcache.delete(_jwk_cache_key(options, kid))
         jwt_key = _get_remote_jwt_key(token, options)
 
         try:
@@ -157,7 +176,8 @@ def _get_remote_jwt_key(token: str, options: VerifyTokenOptions) -> str:
     except jwt.InvalidTokenError as e:
         raise TokenVerificationError(TokenVerificationErrorReason.TOKEN_INVALID) from e
 
-    decoded_pem = __jwkcache.get(kid)
+    cache_key = _jwk_cache_key(options, kid)
+    decoded_pem = __jwkcache.get(cache_key)
     if decoded_pem is not None:
         return decoded_pem
 
@@ -175,7 +195,7 @@ def _get_remote_jwt_key(token: str, options: VerifyTokenOptions) -> str:
                     format=serialization.PublicFormat.SubjectPublicKeyInfo
                 )
                 decoded_pem = pem.decode('utf-8')
-                __jwkcache.set(kid, decoded_pem)
+                __jwkcache.set(cache_key, decoded_pem)
                 return decoded_pem
 
     raise TokenVerificationError(TokenVerificationErrorReason.JWK_KID_MISMATCH)
@@ -216,7 +236,7 @@ async def _verify_session_token_async(token: str, options: VerifyTokenOptions) -
 
         # Key rotation: evict stale cached key, re-fetch, and retry once
         kid = jwt.get_unverified_header(token).get('kid')
-        __jwkcache.delete(kid)
+        __jwkcache.delete(_jwk_cache_key(options, kid))
         jwt_key = await _get_remote_jwt_key_async(token, options)
 
         try:
@@ -291,7 +311,8 @@ async def _get_remote_jwt_key_async(token: str, options: VerifyTokenOptions) -> 
     except jwt.InvalidTokenError as e:
         raise TokenVerificationError(TokenVerificationErrorReason.TOKEN_INVALID) from e
 
-    decoded_pem = __jwkcache.get(kid)
+    cache_key = _jwk_cache_key(options, kid)
+    decoded_pem = __jwkcache.get(cache_key)
     if decoded_pem is not None:
         return decoded_pem
 
@@ -309,7 +330,7 @@ async def _get_remote_jwt_key_async(token: str, options: VerifyTokenOptions) -> 
                     format=serialization.PublicFormat.SubjectPublicKeyInfo
                 )
                 decoded_pem = pem.decode('utf-8')
-                __jwkcache.set(kid, decoded_pem)
+                __jwkcache.set(cache_key, decoded_pem)
                 return decoded_pem
 
     raise TokenVerificationError(TokenVerificationErrorReason.JWK_KID_MISMATCH)

--- a/tests/test_verify_token.py
+++ b/tests/test_verify_token.py
@@ -1,10 +1,18 @@
+import json
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import jwt
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
 from warnings import warn
 
-from clerk_backend_api.security.verifytoken import verify_token, verify_token_async
+from clerk_backend_api.security.verifytoken import (
+    verify_token,
+    verify_token_async,
+    _get_remote_jwt_key,
+    _get_remote_jwt_key_async,
+)
 from clerk_backend_api.security.types import TokenVerificationError, TokenVerificationErrorReason, VerifyTokenOptions, TokenType
 
 from .conftest import has_env_vars
@@ -573,3 +581,75 @@ class TestVerifyTokenAsync:
         assert exc_info.value.reason == TokenVerificationErrorReason.TOKEN_INVALID_SIGNATURE
         assert mock_get_remote_jwt_key.call_count == 2
         assert mock_jwt_decode.call_count == 2
+
+
+class TestJwksCacheInstanceScoping:
+    """Regression tests for AISEC-82.
+
+    The JWKS cache was keyed on the bare `kid`. Since a Clerk `kid` is the
+    instance id, a key cached for one instance was a direct hit for another
+    instance's verification in the same process, so a token minted by
+    instance B authenticated against instance A.
+    """
+
+    @staticmethod
+    def _tenant(kid):
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        jwk = json.loads(RSAAlgorithm.to_jwk(key.public_key()))
+        jwk.update({'kid': kid, 'alg': 'RS256', 'use': 'sig'})
+        token = jwt.encode({'sub': f'user_{kid}'}, key, algorithm='RS256', headers={'kid': kid})
+        return jwk, token
+
+    def _fixtures(self, suffix):
+        # The module-level cache outlives each test, so kids must be unique.
+        jwk_a, _ = self._tenant(f'ins_a_{suffix}')
+        jwk_b, token_b = self._tenant(f'ins_b_{suffix}')
+        jwks = {'sk_test_a': {'keys': [jwk_a]}, 'sk_test_b': {'keys': [jwk_b]}}
+        fetched = []
+
+        def fetch(options):
+            fetched.append(options.secret_key)
+            return jwks[options.secret_key]
+
+        return token_b, fetched, fetch
+
+    def test_cached_key_is_not_served_to_another_instance(self):
+        token_b, fetched, fetch = self._fixtures('sync')
+        opts_a = VerifyTokenOptions(secret_key='sk_test_a')
+        opts_b = VerifyTokenOptions(secret_key='sk_test_b')
+
+        with patch('clerk_backend_api.security.verifytoken._fetch_jwks', side_effect=fetch):
+            pem_b = _get_remote_jwt_key(token_b, opts_b)
+            assert fetched == ['sk_test_b']
+
+            # Instance A must miss the cache and fetch its own JWKS, which
+            # has no such kid.
+            with pytest.raises(TokenVerificationError) as exc_info:
+                _get_remote_jwt_key(token_b, opts_a)
+            assert exc_info.value.reason == TokenVerificationErrorReason.JWK_KID_MISMATCH
+            assert fetched == ['sk_test_b', 'sk_test_a']
+
+            # Instance B's own entry is still cached.
+            assert _get_remote_jwt_key(token_b, opts_b) == pem_b
+            assert fetched == ['sk_test_b', 'sk_test_a']
+
+    @pytest.mark.asyncio
+    async def test_cached_key_is_not_served_to_another_instance_async(self):
+        token_b, fetched, fetch = self._fixtures('async')
+        opts_a = VerifyTokenOptions(secret_key='sk_test_a')
+        opts_b = VerifyTokenOptions(secret_key='sk_test_b')
+
+        async def fetch_async(options):
+            return fetch(options)
+
+        with patch('clerk_backend_api.security.verifytoken._fetch_jwks_async', side_effect=fetch_async):
+            pem_b = await _get_remote_jwt_key_async(token_b, opts_b)
+            assert fetched == ['sk_test_b']
+
+            with pytest.raises(TokenVerificationError) as exc_info:
+                await _get_remote_jwt_key_async(token_b, opts_a)
+            assert exc_info.value.reason == TokenVerificationErrorReason.JWK_KID_MISMATCH
+            assert fetched == ['sk_test_b', 'sk_test_a']
+
+            assert await _get_remote_jwt_key_async(token_b, opts_b) == pem_b
+            assert fetched == ['sk_test_b', 'sk_test_a']


### PR DESCRIPTION
The module-level JWKS cache was keyed on the bare `kid`. Because a Clerk `kid` is the instance id, a key cached for one instance was a direct hit for another instance's verification in the same process, and the lookup short-circuits before `secret_key` is ever consulted. Combined with `verify_iss: False`, a session token minted by instance B authenticated against instance A in any multi-tenant process.

Cache entries are now scoped by a hash of the api_url and secret_key, so a cross-instance lookup misses and forces the secret-key-authorized fetch, which returns only that instance's keys. Covers the sync and async paths.

Fixes AISEC-82