### PR TITLE
fix: fail closed on negative v2 feature-permission masks

### DIFF
--- a/src/clerk_backend_api/security/authenticaterequest.py
+++ b/src/clerk_backend_api/security/authenticaterequest.py
@@ -1,3 +1,4 @@
+import re
 from http.cookies import SimpleCookie
 from typing import Any, Dict, List, Optional
 
@@ -9,6 +10,11 @@ from .verifytoken import (
     verify_token,
     verify_token_async,
 )
+
+
+# ASCII digits only: str.isdigit() and the regex \d class both accept other
+# Unicode digit forms, which are not valid in a JWT claim.
+_DECIMAL_MASK = re.compile(r"[0-9]+")
 
 
 def _compute_org_permissions(claims: Dict[str, Any]) -> List[str]:
@@ -40,10 +46,16 @@ def _compute_org_permissions(claims: Dict[str, Any]) -> List[str]:
         if "o" not in scope:
             continue
 
-        try:
-            binary = bin(int(mapping))[2:].lstrip("0")
-        except ValueError:
+        # Only a non-negative decimal integer is a valid mask. A negative value
+        # means the issuer overflowed a signed integer while encoding, and
+        # bin() renders it as "-0b111...", so the [2:] slice would leave a
+        # stray "b" and the remaining digits would grant the magnitude's bits --
+        # permissions that were never assigned. Reject rather than guess,
+        # mirroring decimalToBinaryBits in @clerk/shared.
+        if _DECIMAL_MASK.fullmatch(mapping) is None:
             continue
+
+        binary = bin(int(mapping))[2:].lstrip("0")
 
         reversed_binary = binary[::-1]
 

--- a/tests/test_org_permissions_v2.py
+++ b/tests/test_org_permissions_v2.py
@@ -1,0 +1,88 @@
+"""Tests for decoding v2 session token org permissions (`fea` / `o.per` / `o.fpm`).
+
+A permission key is `org:<feature>:<action>`. The token factors these into an
+ordered feature list, a shared action vocabulary, and one bitmask per feature
+over that vocabulary. Bit j of mask i means feature i grants action j, with
+bit 0 least significant.
+"""
+
+import pytest
+
+from clerk_backend_api.security.authenticaterequest import _compute_org_permissions
+
+
+def claims(fea: str, per: str, fpm: str):
+    return {"fea": fea, "o": {"per": per, "fpm": fpm}}
+
+
+def test_decodes_a_normal_mask():
+    assert _compute_org_permissions(
+        claims("o:leads,o:whatsapp", "read,manage", "3,1")
+    ) == ["org:leads:read", "org:leads:manage", "org:whatsapp:read"]
+
+
+def test_decodes_bit_62():
+    perms = ",".join(f"p{i:02d}" for i in range(80))
+    assert _compute_org_permissions(
+        claims("o:repositories", perms, str((1 << 62) | 1))
+    ) == ["org:repositories:p00", "org:repositories:p62"]
+
+
+def test_decodes_a_positive_bignum_at_bit_63():
+    """Python ints are arbitrary-precision, so a wide positive mask is exact."""
+    perms = ",".join(f"p{i:02d}" for i in range(80))
+    assert _compute_org_permissions(
+        claims("o:repositories", perms, str((1 << 63) | 1))
+    ) == ["org:repositories:p00", "org:repositories:p63"]
+
+
+def test_decodes_beyond_64_bits():
+    perms = ",".join(f"p{i:02d}" for i in range(80))
+    assert _compute_org_permissions(
+        claims("o:repositories", perms, str((1 << 72) | 1))
+    ) == ["org:repositories:p00", "org:repositories:p72"]
+
+
+@pytest.mark.parametrize(
+    "mask",
+    [
+        "-9223372036854775807",
+        "-9223372036854775808",
+        "-1",
+    ],
+)
+def test_negative_masks_grant_nothing(mask):
+    """A negative mask can only come from an issuer that overflowed a signed
+    integer. bin() renders it as "-0b111...", so slicing off two characters
+    leaves a stray "b" and the magnitude's bits, which previously granted
+    permissions that were never assigned -- 63 of them for the first case."""
+    perms = ",".join(f"p{i:02d}" for i in range(80))
+    assert _compute_org_permissions(claims("o:repositories", perms, mask)) == []
+
+
+@pytest.mark.parametrize("mask", ["0x1f", "1.5", "", " 3", "3 ", "abc", "+3", "１"])
+def test_non_decimal_masks_grant_nothing(mask):
+    assert _compute_org_permissions(claims("o:repositories", "read,manage", mask)) == []
+
+
+def test_zero_mask_grants_nothing():
+    assert _compute_org_permissions(claims("o:repositories", "read,manage", "0")) == []
+
+
+def test_mask_wider_than_the_vocabulary_is_bounded():
+    """Extra high bits must not emit permissions with no action name."""
+    assert _compute_org_permissions(
+        claims("o:repositories", "read,manage", str((1 << 40) | 1))
+    ) == ["org:repositories:read"]
+
+
+def test_user_scoped_features_are_skipped():
+    assert _compute_org_permissions(
+        claims("u:impersonation,o:leads", "read,manage", "1,1")
+    ) == ["org:leads:read"]
+
+
+def test_more_masks_than_features_are_ignored():
+    assert _compute_org_permissions(claims("o:leads", "read,manage", "1,3")) == [
+        "org:leads:read"
+    ]


### PR DESCRIPTION
`_compute_org_permissions` decodes each `o.fpm` mask with `bin(int(mapping))[2:]`. That is correct for a non-negative mask and **fails open** on a negative one: `bin(-9223372036854775807)` is `'-0b111…1'`, so the minus sign shifts the slice and leaves a stray `'b'` followed by the magnitude's bits. Walking that grants permissions that were never assigned — 63 of them for that mask, against a two-permission grant.

This is reachable today. The backend accumulates these masks in a signed 64-bit integer, so any instance with 64 or more distinct custom permission action keys produces a negative mask for an action at index 63. One instance currently in that range uses this SDK.

## Fix

Reject any mask that is not a non-negative ASCII decimal before decoding, mirroring `decimalToBinaryBits` in `@clerk/shared`, which fails closed the same way.

Large positive masks are deliberately untouched — Python ints are arbitrary-precision, so a mask wider than 64 bits already decodes exactly. No width cap is introduced; only negatives and non-numerics are rejected.

The pattern is `[0-9]+` rather than `\d+` or `str.isdigit()`, both of which accept other Unicode digit forms that are not valid in a JWT claim.

`security/authenticaterequest.py` is not in `.speakeasy/gen.lock`'s `generatedFiles`, so this is hand-written and no regeneration is involved.

## Tests

New `tests/test_org_permissions_v2.py` — 19 cases covering normal masks, bit 62, a positive bignum at bit 63, a mask beyond 64 bits, negative masks granting nothing, non-decimal masks, over-wide masks, user-scoped features, and more masks than features. Against unpatched `authenticaterequest.py` these give 7 failures; patched, all 19 pass.

Full suite: 77 passed, 14 skipped. The 3 errors in `test_clerk_before_request_hook.py` reproduce on a clean `main` and are unrelated.

Part of CORE-3701

🤖 Generated with [Claude Code](https://claude.com/claude-code)